### PR TITLE
Disable overflow override when the wallet modal is opened

### DIFF
--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fractalwagmi/wallet-adapter-react-ui",
-    "version": "0.0.10",
+    "version": "0.0.11-alpha.1",
     "author": "Dan Borstelmann",
     "repository": "https://github.com/fractalwagmi/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fractalwagmi/wallet-adapter-react-ui",
-    "version": "0.0.11-alpha.1",
+    "version": "0.0.11",
     "author": "Dan Borstelmann",
     "repository": "https://github.com/fractalwagmi/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/ui/react-ui/src/WalletModal.tsx
+++ b/packages/ui/react-ui/src/WalletModal.tsx
@@ -120,14 +120,15 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
         const { overflow } = window.getComputedStyle(document.body);
         // Hack to enable fade in animation after mount
         setTimeout(() => setFadeIn(true), 0);
-        // Prevent scrolling on mount
-        document.body.style.overflow = 'hidden';
+        // Prevent scrolling on mount: disable this behavior because the unmount fn doesn't
+        // run correctly (line 131 therefore never happens)
+        // document.body.style.overflow = 'hidden';
         // Listen for keydown events
         window.addEventListener('keydown', handleKeyDown, false);
 
         return () => {
             // Re-enable scrolling when component unmounts
-            document.body.style.overflow = overflow;
+            // document.body.style.overflow = overflow;
             window.removeEventListener('keydown', handleKeyDown, false);
         };
     }, [hideModal, handleTabKey]);


### PR DESCRIPTION
As title. This is an attempt to fix the page scroll issue in a different way since we have a fork of the source repo.

For some reason the callback from `useLayoutEffect` is never executed on component unmount so we never reset the overflow value that's overriden on `body`.

I previously added a hack in main app that overrides the css value with `!important` but this caused all other dialogs to always allow the main body to be scrolling.

This should in theory remove the need for the hack. it will cause the solana wallets modal body to be scrollable, but that's better than all dialogs on the site.
